### PR TITLE
Merge fix-example2 Changes

### DIFF
--- a/examples/scanner/scanner_advanced.py
+++ b/examples/scanner/scanner_advanced.py
@@ -24,7 +24,7 @@ def on_scan(advertisement):
         # print(f"  Calibration state: {mf_data.calibration_state.name}")
         # print(f"  DFU Active:        {mf_data.dfu_active:}")
 
-    print(f"  RSSI:              {advertisement.device.rssi} dBm")
+    print(f"  RSSI:              {advertisement.rssi} dBm")
 
     if advertisement.readings:
         print("--------------------------------------")
@@ -32,7 +32,7 @@ def on_scan(advertisement):
         print(f"  Temperature:   {advertisement.readings.temperature:.01f} \u00b0C")
         print(f"  Humidity:      {advertisement.readings.humidity} %")
         print(f"  Pressure:      {advertisement.readings.pressure:.01f} hPa")
-        print(f"  Battery:       {advertisement.readings.battery} &")
+        print(f"  Battery:       {advertisement.readings.battery} %")
         print(f"  Status disp.:  {advertisement.readings.status.name}")
         print(f"  Ago:           {advertisement.readings.ago} s")
     print()


### PR DESCRIPTION
- `BLEDevice.rssi` is deprecated since version 0.19.0 (see https://bleak.readthedocs.io/en/latest/api/index.html#bleak.backends.device.BLEDevice.rssi) switched to using the advertisement rssi (see https://bleak.readthedocs.io/en/latest/api/scanner.html#bleak.BleakScanner.discover).
- Battery has a "&" symbol after it instead of a percentage symbol (typo?).